### PR TITLE
⚡ Bolt: CI efficiency optimization

### DIFF
--- a/.github/workflows/snorkell-auto-documentation.yml
+++ b/.github/workflows/snorkell-auto-documentation.yml
@@ -2,14 +2,26 @@
 
 name: Penify - Revolutionizing Documentation on GitHub
 
+# ⚡ Efficiency: Prevents redundant runs by cancelling in-progress executions for the same workflow/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main"]
+    # ⚡ Performance: Skip documentation generation for non-code/meta changes
+    paths-ignore:
+      - 'README.md'
+      - '.github/workflows/**'
+      - '.jules/**'
   workflow_dispatch:
 
 jobs:
   Documentation:
     runs-on: ubuntu-latest
+    # ⚡ Performance: Fail fast and release resources if the job hangs
+    timeout-minutes: 15
     steps:
     - name: Penify DocGen Client
       uses: SingularityX-ai/snorkell-documentation-client@v1.0.0

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-06-20 - CI efficiency as a primary performance lever in minimal repositories
+
+**Learning:** In repositories that consist primarily of configuration and documentation (lacking application source code), GitHub Actions workflows are the most impactful area for performance and resource optimization. Standard guards like `concurrency`, `paths-ignore`, and `timeout-minutes` significantly reduce wasted compute time.
+
+**Action:** Always check `.github/workflows` for missing efficiency guards when working in minimal or infrastructure-heavy repositories.


### PR DESCRIPTION
I've optimized the `snorkell-auto-documentation.yml` workflow to be more efficient and resource-conscious.

Key improvements:
1. **Concurrency Control:** Added a concurrency group to ensure that only one instance of the workflow runs per branch at a time, cancelling any previous runs that are still in progress.
2. **Path Filtering:** Configured `paths-ignore` to prevent the workflow from triggering on changes to non-source files like `README.md`, the workflow definitions themselves, and the `.jules` directory.
3. **Timeout:** Added a 15-minute timeout to the job as a safety measure to prevent it from hanging indefinitely.
4. **Bolt Journal:** Initialized the Bolt performance journal at `.jules/bolt.md` to track critical learnings for this repository.

These changes directly improve the efficiency of the repository's CI pipeline and reduce wasted compute resources.

---
*PR created automatically by Jules for task [373006912817169844](https://jules.google.com/task/373006912817169844) started by @hussamgalal999*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized the `snorkell-auto-documentation.yml` CI workflow to reduce redundant runs and skip non-source changes, cutting wasted compute. Also added a Bolt performance journal for CI learnings.

- **Refactors**
  - Added `concurrency` per workflow/branch to cancel in-progress runs.
  - Ignored paths: `README.md`, `.github/workflows/**`, `.jules/**`.
  - Set `timeout-minutes: 15` on the `Documentation` job.
  - Added `.jules/bolt.md` to capture performance learnings.

<sup>Written for commit 50b6dd3d1f140f39b393990c084046d6e4159c48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hussamgalal999/modern-port/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

